### PR TITLE
Update/Create Make Targets for clean/clean_lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+lib
 
 CMakeLists.txt.user
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ target_link_libraries(${PROJECT_ELF_FILE} m) # Math library required for sqrt(),
 
 ADD_CUSTOM_TARGET(
     flash
-    COMMAND ${CMAKE_OBJCOPY} -Obinary ${PROJECT_ELF_FILE} ${PROJECT_BIN_FILE} # TODO
+    COMMAND ${CMAKE_OBJCOPY} -Obinary ${PROJECT_ELF_FILE} ${PROJECT_BIN_FILE}
     COMMAND st-flash write ${PROJECT_BIN_FILE} 0x8000000
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,19 @@ ADD_EXECUTABLE(
     system_stm32f4xx.c
     )
 
+ADD_EXECUTABLE(
+    ${PROJECT_BIN_FILE}
+    ${PROJECT_SOURCES}
+    ${STM32STD_SOURCES}
+    ${STM32Discovery_SOURCES}
+    ${STM32LL_SOURCES}
+    ${FreeRTOS_SOURCES}
+    ${uGFX_SOURCES}
+    gdisp_lld_ILI9341.c
+    startup_stm32f429_439xx.S
+    system_stm32f4xx.c
+    )
+
 target_link_libraries(${PROJECT_ELF_FILE} m) # Math library required for sqrt(),...
 
 ADD_CUSTOM_TARGET(
@@ -142,4 +155,11 @@ STM32_SET_TARGET_PROPERTIES(${PROJECT_ELF_FILE})
 STM32_ADD_HEX_BIN_TARGETS(${PROJECT_ELF_FILE})
 STM32_PRINT_SIZE_OF_TARGETS(${PROJECT_ELF_FILE})
 
-# TODO: also clean .bin file on `make clean`
+ADD_CUSTOM_TARGET(
+    clean_lib
+    DEPENDS cleanlib
+    )
+
+add_custom_command(OUTPUT cleanlib
+    COMMAND ${CMAKE_COMMAND} -P "cmake/cleanall.cmake"
+    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,16 +93,15 @@ INCLUDE_DIRECTORIES(
     ${uGFX_INCLUDE_DIRS}
     )
 
-file(GLOB PROJECT_SOURCES "src/*.c")
+file(GLOB USER_SOURCES "src/*.c")
 
 SET(STM32_LINKER_SCRIPT ${CMSIS_LINKER_SCRIPT})
 
 SET(PROJECT_ELF_FILE ${CMAKE_PROJECT_NAME}.elf)
 SET(PROJECT_BIN_FILE ${CMAKE_PROJECT_NAME}.bin)
 
-ADD_EXECUTABLE(
-    ${PROJECT_ELF_FILE}
-    ${PROJECT_SOURCES}
+SET(PROJECT_SOURCES
+    ${USER_SOURCES}
     ${STM32STD_SOURCES}
     ${STM32Discovery_SOURCES}
     ${STM32LL_SOURCES}
@@ -114,16 +113,8 @@ ADD_EXECUTABLE(
     )
 
 ADD_EXECUTABLE(
-    ${PROJECT_BIN_FILE}
+    ${PROJECT_ELF_FILE}
     ${PROJECT_SOURCES}
-    ${STM32STD_SOURCES}
-    ${STM32Discovery_SOURCES}
-    ${STM32LL_SOURCES}
-    ${FreeRTOS_SOURCES}
-    ${uGFX_SOURCES}
-    gdisp_lld_ILI9341.c
-    startup_stm32f429_439xx.S
-    system_stm32f4xx.c
     )
 
 target_link_libraries(${PROJECT_ELF_FILE} m) # Math library required for sqrt(),...
@@ -132,9 +123,19 @@ ADD_CUSTOM_TARGET(
     flash
     COMMAND ${CMAKE_OBJCOPY} -Obinary ${PROJECT_ELF_FILE} ${PROJECT_BIN_FILE}
     COMMAND st-flash write ${PROJECT_BIN_FILE} 0x8000000
+    COMMAND rm ${PROJECT_BIN_FILE}
     )
 
 ADD_DEPENDENCIES(flash ${PROJECT_ELF_FILE})
+
+ADD_CUSTOM_TARGET(clean_cmake
+    COMMAND ${CMAKE_BUILD_TOOL} clean
+    COMMAND git clean -d -f -x
+    )
+
+ADD_CUSTOM_TARGET(clean_all
+    COMMAND git clean -d ${PROJECT_SOURCE_DIR} -f -f -x
+    )
 
 if(${DISCOVERY_BOARD_DISC1})
     set(OPENOCD_BOARD "board/stm32f429disc1.cfg")

--- a/cmake/cleanall.cmake
+++ b/cmake/cleanall.cmake
@@ -1,4 +1,0 @@
-message("Removing downloaded libraries...")
-file(REMOVE_RECURSE lib)
-file(MAKE_DIRECTORY lib)
-message("Done!")

--- a/cmake/cleanall.cmake
+++ b/cmake/cleanall.cmake
@@ -1,0 +1,4 @@
+message("Removing downloaded libraries...")
+file(REMOVE_RECURSE lib)
+file(MAKE_DIRECTORY lib)
+message("Done!")


### PR DESCRIPTION
Beside a small documentation fix this should implement 2 features:
1. remove `*.bin` file on `make clean`
2. add `clean_lib` target to remove downloaded libraries.

I do not see any reason in cleaning Cmake-related files, too.

I am unfortunately very dissatisfied with both of my implementation and as I was not able to find ways to implement the features properly.

here is a list of things, that should actually be improved:
- I managed to remove the .bin file by making it an executable, passing the same source files as for the elf file. This could lead to problems as changes have to be done to both parts of the CmakeList.txt. If actually wanted to use `ADDITIONAL_CLEAN_FILES` but for whatever reason to did not have an effect.
- I wanted to create a target called `clean_all` depending on `clean` but was not able to do this as `DEPENDS clean` resulted in an error.
- To remove the contents of the `lib` directory to created an additional file `cmake/cleanall.cmake` with is loaded when the corresponding make target is called. This has the problem that the path to the CMake file as well as the path for the library is hardcoded. Using  a simple `rm` command instead of `file(REMOVE_RECURSE ...` could be a better option...